### PR TITLE
Example site: fix invalid config.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,5 @@ Temporary Items
 
 .vscode
 
-# customize Headers whiteout touch git submodule.
+# customize headers without touching git submodule.
 layouts/partials/extra-head.html

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 
-![Hello Friend 4s3ti](images/Screenshot.png)
+![Hello Friend 4s3ti](images/screenshot.png)
 
 ## General informations
 
@@ -189,7 +189,7 @@ audio: path/to/file.mp3
 
 ## Social Icons:
 
-### FontAweome
+### FontAwesome
 
 To use the Social Media icons and the Share Icons you are required to have at least a free [FontAwesome](https://fontawesome.com) Icon Kit   
 

--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -1,0 +1,3 @@
+.hugo_build.lock
+public/
+resources/

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -32,8 +32,8 @@ disableRSS     = false
 disableSitemap = false
 disable404     = false
 disableHugoGeneratorInject = false
-IsMultiLangual = false
-defaultContentLanguage = pt-pt
+IsMultiLingual = false
+defaultContentLanguage = "en"
 
 
 [permalinks]
@@ -134,7 +134,7 @@ defaultContentLanguage = pt-pt
   # If you want, you can easily override the default footer with your own content. 
   #
   [params.fontAwesome]
-    KitURL = https://kit.fontawesome.com/KitID.js
+    KitURL = "https://kit.fontawesome.com/KitID.js"
 
   [params.footer]
     trademark = true
@@ -195,7 +195,7 @@ defaultContentLanguage = pt-pt
   [[params.social]]
     name = "email"
     url  = "mailto:nobody@example.com"
-    icon = fa-solid fa-envelope
+    icon = "fa-solid fa-envelope"
 
   [[params.social]]
     name = "github"
@@ -211,14 +211,15 @@ defaultContentLanguage = pt-pt
 
 [languages]
   [languages.en]
-    subtitle  = "Hello 4s3ti Theme"
     weight    = 1
     copyright = '<a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noopener">CC BY-NC 4.0</a>'
-
-  [languages.fr]
+  [languages.en.params]
     subtitle  = "Hello 4s3ti Theme"
+  [languages.fr]
     weight    = 2
     copyright = '<a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noopener">CC BY-NC 4.0</a>'
+  [languages.fr.params]
+    subtitle  = "Hello 4s3ti Theme"
 
 [menu]
   [[menu.main]]


### PR DESCRIPTION
This PR fixes various issues found:
- fix exampleSite in case of using hugo 0.113.0
- avoid warnings with hugo 0.113.0
- correct invalid link for screenshot (`README.md`)
- fixing typos
- improve .gitignore
